### PR TITLE
fix embed content

### DIFF
--- a/src/RitsukageBotForDiscord/Modules/AI/AiInteractions.Chatting.cs
+++ b/src/RitsukageBotForDiscord/Modules/AI/AiInteractions.Chatting.cs
@@ -133,11 +133,15 @@ namespace RitsukageBot.Modules.AI
             var showPreprocessingAction = ChatClientProvider.GetConfig<bool>("ShowPreprocessingAction");
             if (preprocessingActionData is not null && showPreprocessingAction)
             {
-                var embedBuilder = new EmbedBuilder();
-                embedBuilder.WithDescription(string.Join(Environment.NewLine,
-                    preprocessingActionData.Select(x => x.Action)));
-                embedBuilder.WithColor(Color.DarkPurple);
-                preprocessingEmbed = embedBuilder.Build();
+                var preprocessingActionDataStr = string.Join(Environment.NewLine,
+                    preprocessingActionData.Select(x => x.Action));
+                if (!string.IsNullOrWhiteSpace(preprocessingActionDataStr))
+                {
+                    var embedBuilder = new EmbedBuilder();
+                    embedBuilder.WithDescription(preprocessingActionDataStr);
+                    embedBuilder.WithColor(Color.DarkPurple);
+                    preprocessingEmbed = embedBuilder.Build();
+                }
             }
 
             var generatingEmbed = new EmbedBuilder();


### PR DESCRIPTION
This pull request refines how preprocessing action data is handled before generating a response in the `AiInteractions.Chatting.cs` module. The main improvement is ensuring that the preprocessing embed is only created and shown if there is meaningful preprocessing action data to display.

**Enhancement to preprocessing action display:**

* Updated the logic in `await ModifyOriginalResponseAsync(x => ... )` to only create and show the preprocessing embed if the joined preprocessing action data string is not empty or whitespace, preventing empty embeds from being displayed.